### PR TITLE
IMTA 13521: update trufflehog installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ It is used as a pre-push hook and will scan any local commits being pushed
 
 ### Pre-push hook setup
 1. Install [truffleHog](https://github.com/trufflesecurity/truffleHog)
-    - `brew install go`
-    - `git clone https://github.com/trufflesecurity/trufflehog.git`
-    - `cd trufflehog; go install`
+    - `brew install trufflesecurity/trufflehog/trufflehog`
 2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
 3. Potentially there's an older version of Trufflehog located at: `/usr/local/bin/trufflehog`. If so, remove this.
-4. Create a symlink: `ln -s ~/go/bin/truffleHog /usr/local/bin/trufflehog`
-5. From this project root directory copy the pre-push hook: `cp hooks/pre-push .git/hooks/pre-push`
 
 ### Git hook setup
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Abhishek Dutt (Kainos) |
> | **GitLab Project** | [imports/notify-microservice](https://giteux.azure.defra.cloud/imports/notify-microservice) |
> | **GitLab Merge Request** | [IMTA 13521: update trufflehog installati...](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/25) |
> | **GitLab MR Number** | [25](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/25) |
> | **Date Originally Opened** | Tue, 26 Sep 2023 |
> | **Approved on GitLab by** | Odran Muldoon (Kainos), Shawn Chan (Kainos), Thomas Seelig (Kainos), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13521)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13521-Inconsistencies_with_Trufflehog_versions&id=Imports-FUNC-Notify)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/notify-microservice/job/feature%2FIMTA-13521-Inconsistencies_with_Trufflehog_versions/)

### :book: Changes:

- update TruffleHog installation notes
- verify pre-push hook triggers TruffleHog scan