### PR TITLE
WIP: IMTA-11274: bump spring-boot-starter-webflux to version 2.6.3

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.2</version>
+    <version>2.6.3</version>
     <relativePath/>
   </parent>
 
@@ -24,7 +24,6 @@
     <azure.functions.java.library.version>1.4.0</azure.functions.java.library.version>
     <azure.functions.maven.plugin.version>1.9.0</azure.functions.maven.plugin.version>
     <azure.core.serializer.json.jackson.version>1.2.8</azure.core.serializer.json.jackson.version>
-    <spring.boot.webflux.version>2.6.3</spring.boot.webflux.version>
     <commons.io.version>2.6</commons.io.version>
     <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
     <javax.xml.bind.version>2.3.0</javax.xml.bind.version>
@@ -63,7 +62,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
-      <version>${spring.boot.webflux.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -24,6 +24,7 @@
     <azure.functions.java.library.version>1.4.0</azure.functions.java.library.version>
     <azure.functions.maven.plugin.version>1.9.0</azure.functions.maven.plugin.version>
     <azure.core.serializer.json.jackson.version>1.2.8</azure.core.serializer.json.jackson.version>
+    <spring.boot.webflux.version>2.6.3</spring.boot.webflux.version>
     <commons.io.version>2.6</commons.io.version>
     <jacoco.maven.plugin.version>0.8.2</jacoco.maven.plugin.version>
     <javax.xml.bind.version>2.3.0</javax.xml.bind.version>
@@ -62,6 +63,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
+      <version>${spring.boot.webflux.version}</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lewis Birks (Kainos) |
> | **GitLab Project** | [imports/notify-microservice](https://giteux.azure.defra.cloud/imports/notify-microservice) |
> | **GitLab Merge Request** | [WIP: IMTA-11274: bump spring-boot-starte...](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/8) |
> | **GitLab MR Number** | [8](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/8) |
> | **Date Originally Opened** | Wed, 9 Feb 2022 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11274

### :book: Changes:
* fix version of spring-boot-starter-webflux to 2.6.3