### PR TITLE
IMTA-11688: Updated spring-boot-starter-parent to v.2.6.6

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.2</version>
+    <version>2.6.6</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marc-Steeven Eyeni-Kantsey (Kainos) |
> | **GitLab Project** | [imports/notify-microservice](https://giteux.azure.defra.cloud/imports/notify-microservice) |
> | **GitLab Merge Request** | [IMTA-11688: Updated spring-boot-starter-...](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/10) |
> | **GitLab MR Number** | [10](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/10) |
> | **Date Originally Opened** | Thu, 21 Apr 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Charles.Luo, Lewis Birks (Kainos), Reece Bennett (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Updated spring-boot-starter-parent package to v.2.6.6