### PR TITLE
IMTA-12097: Publish notify microservice code in the open

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -5,10 +5,23 @@
 Java Azure Function to notify drivers/hauliers by email/text when a notification has been selected for 
 inspection.
 
+## Secret scanning
+Secret scanning is setup using [truffleHog](https://github.com/trufflesecurity/truffleHog).
+It is used as a pre-push hook and will scan any local commits being pushed
+
+### Pre-push hook setup
+1. Install [truffleHog](https://github.com/trufflesecurity/truffleHog)
+    - `brew install go`
+    - `git clone https://github.com/trufflesecurity/trufflehog.git`
+    - `cd trufflehog; go install`
+2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
+3. Potentially there's an older version of Trufflehog located at: `/usr/local/bin/trufflehog`. If so, remove this.
+4. Create a symlink: `ln -s ~/go/bin/truffleHog /usr/local/bin/trufflehog`
+5. From this project root directory copy the pre-push hook: `cp hooks/pre-push .git/hooks/pre-push`
+
 ## Set up
 
-Ensure that you have the necessary configuration to resolve dependencies from Artifactory:
-https://eaflood.atlassian.net/wiki/spaces/IT/pages/1047823027/Artifactory.
+Ensure that you have the necessary configuration to resolve dependencies from Artifactory.
 
 Copy the .env file from Sharepoint into the root of this project.
 
@@ -85,18 +98,18 @@ browser.
 When the function is initiated the runtime environment is validated to ensure that all required
 variables have been set.
 
-| Environment variable | Description | Example |
-| -------------------- | ----------- | ------- |
-| `PROTOCOL` | The HTTP protocol used when connecting to IPAFFS components | `https` |
-| `ENV_DOMAIN` | The IPAFFS deployment domain (e.g. pool number or RTL environment) | `-integration.azurewebsites.net` |
-| `NOTIFY_QUEUE_NAME` | The name of the notify service bus queue | `notify_queue` |
-| `ENABLE_EMAIL_NOTIFICATION` | Flag to enable or disable email notify functionality | `false/true` |
-| `ENABLE_TEXT_NOTIFICATION` | Flag to enable or disable text notify functionality | `false/true` |
-| `TRADE_PLATFORM_AUTH_URL` | Trade Auth URL for token generation | |
-| `TRADE_PLATFORM_NOTIFY_URL` | Trade Notify URL for email/Text Notification | |
-| `TRADE_PLATFORM_CLIENT_ID` | Trade Platform client ID | |
-| `TRADE_PLATFORM_CLIENT_SECRET` | Trade Platform client Secret | |
-| `TRADE_PLATFORM_SCOPE` | Trade Platform Scope | |
-| `TRADE_PLATFORM_SYSTEM_NAME` | Trade Platform System Name | `IPAFFS` |
-| `TRADE_PLATFORM_SYSTEM_UNIQUE_ID` | Trade Platform System Unique ID | |
-| `TRADE_PLATFORM_SUBSCRIPTION_KEY` | Trade Platform Subscription Key | |
+| Environment variable | Description |
+| -------------------- | ----------- |
+| `PROTOCOL` | The HTTP protocol used when connecting to IPAFFS components |
+| `ENV_DOMAIN` | The IPAFFS deployment domain (e.g. pool number or RTL environment) |
+| `NOTIFY_QUEUE_NAME` | The name of the notify service bus queue |
+| `ENABLE_EMAIL_NOTIFICATION` | Flag to enable or disable email notify functionality |
+| `ENABLE_TEXT_NOTIFICATION` | Flag to enable or disable text notify functionality |
+| `TRADE_PLATFORM_AUTH_URL` | Trade Auth URL for token generation |
+| `TRADE_PLATFORM_NOTIFY_URL` | Trade Notify URL for email/Text Notification |
+| `TRADE_PLATFORM_CLIENT_ID` | Trade Platform client ID |
+| `TRADE_PLATFORM_CLIENT_SECRET` | Trade Platform client Secret |
+| `TRADE_PLATFORM_SCOPE` | Trade Platform Scope |
+| `TRADE_PLATFORM_SYSTEM_NAME` | Trade Platform System Name |
+| `TRADE_PLATFORM_SYSTEM_UNIQUE_ID` | Trade Platform System Unique ID |
+| `TRADE_PLATFORM_SUBSCRIPTION_KEY` | Trade Platform Subscription Key |

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+NO_COLOUR='\033[0m'
+LOG_PREFIX="Pre-push hook:"
+FAILED_MESSAGE="${LOG_PREFIX} ${RED}[FAILED]${NO_COLOUR}"
+REPO_NAME="notify-microservice"
+
+trufflehog --help > /dev/null 2>&1 || { echo -e "${FAILED_MESSAGE} truffleHog is not installed. Please install via https://github.com/trufflesecurity/truffleHog" ; exit 1; }
+[ -z "$DEFRA_WORKSPACE" ] && echo -e "${FAILED_MESSAGE} Please set DEFRA_WORKSPACE env var to your Defra workspace" && exit 1;
+
+echo "${LOG_PREFIX} RUNNING truffleHog to test for leaked secrets."
+trufflehog git --fail --regex --since_commit "$(git rev-parse origin/HEAD)" --branch "$(git rev-parse --abbrev-ref HEAD)" file://"${DEFRA_WORKSPACE}"/${REPO_NAME}
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  echo -e "${FAILED_MESSAGE} truffleHog found some suspicious commits containing possible secrets"
+  echo -e "${FAILED_MESSAGE} git push failed, Please remove the secrets caught by truffleHog"
+  exit 1
+else
+  echo "${LOG_PREFIX} OK proceeding with push"
+  exit 0
+fi

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -31,7 +31,7 @@
     <json.unit.version>2.28.0</json.unit.version>
     <log4j2.version>2.17.1</log4j2.version>
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
-    <owasp.version>6.0.1</owasp.version>
+    <owasp.version>6.5.3</owasp.version>
     <system-lambda.version>1.1.1</system-lambda.version>
 
     <stagingDirectory>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ben Doherty (Kainos) |
> | **GitLab Project** | [imports/notify-microservice](https://giteux.azure.defra.cloud/imports/notify-microservice) |
> | **GitLab Merge Request** | [IMTA-12097: Publish notify microservice ...](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/11) |
> | **GitLab MR Number** | [11](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/11) |
> | **Date Originally Opened** | Mon, 27 Jun 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Jahir, Sifat (KAINOS), Kelly Moore, Lewis Birks (Kainos), Nicholas Martin, akbar shaik (Kainos), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12097)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-12097-code-in-the-open&id=Imports-Notify-FunctionApp)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/notify-microservice/job/feature%2FIMTA-12097-code-in-the-open/)

### :book: Changes:
* Add secret scanning
* Add git hook
* Update README
* Bump OWASP version in pom for consistency in dependency reporting with Jenkins