### PR TITLE
IMTA-12131: Bumped up spring boot starter parent to fix security crypto package issue

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.7.1</version>
     <relativePath/>
   </parent>
 
@@ -104,7 +104,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
-      <version>${okhttp3.version}</version>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marc-Steeven Eyeni-Kantsey (Kainos) |
> | **GitLab Project** | [imports/notify-microservice](https://giteux.azure.defra.cloud/imports/notify-microservice) |
> | **GitLab Merge Request** | [IMTA-12131: Bumped up spring boot starte...](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/12) |
> | **GitLab MR Number** | [12](https://giteux.azure.defra.cloud/imports/notify-microservice/merge_requests/12) |
> | **Date Originally Opened** | Tue, 28 Jun 2022 |
> | **Approved on GitLab by** | Lewis Birks (Kainos), Thomas Seelig (Kainos), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12131)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-12131-fix-vulnerability-in-spring-security-crypto&id=Imports-Notify-FunctionApp)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/notify-microservice/job/bugfix%2FIMTA-12131-fix-vulnerability-in-spring-security-crypto/)

### :book: Changes:
* Bumped up spring boot parent to latest version (2.0.205) to fix security crypto package issue

### :white_check_mark: Selenium Test Run:

PENDING